### PR TITLE
Development

### DIFF
--- a/CruiseDesign.Test/CruiseDesign.Test.csproj
+++ b/CruiseDesign.Test/CruiseDesign.Test.csproj
@@ -35,7 +35,6 @@
 		<PackageReference Include="CruiseDAL.V3.DownConvert" Version="3.6.5.12200" />
 		<PackageReference Include="CruiseDAL.V3.Models" Version="*" />
 		<PackageReference Include="NSubstitute" Version="5.1.0" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="*" />
 		<PackageReference Include="FluentAssertions" Version="6.6.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />

--- a/CruiseDesign.Test/CruiseDesignMain_Test_OpenExistingDesignFile.cs
+++ b/CruiseDesign.Test/CruiseDesignMain_Test_OpenExistingDesignFile.cs
@@ -21,36 +21,6 @@ namespace CruiseDesign.Test
         }
 
         [Theory]
-        [InlineData(270)]
-        [InlineData(260)]
-        [InlineData(258)]
-
-        public void OpenExistingDesignFile_PathTooLong(int desiredDirLength)
-        {
-            var fileName = "a.design";
-            var dir = base.TestTempPath;
-            var baseDirLength = dir.Length;
-            var neededExtraDirLength = desiredDirLength - baseDirLength - fileName.Length; 
-
-            var extraDir = new String('a', neededExtraDirLength);
-
-            var targetPath = Path.Combine(dir, extraDir, "a.design");
-            Output.WriteLine("TargetPath::::(" + targetPath.Length + ")" + targetPath);
-
-            var fileContextProvider = new CruiseDesignFileContextProvider();
-
-            var logger = MakeMockLogger();
-            var dialogService = MakeMockDialogService();
-
-            if (File.Exists(targetPath)) { File.Delete(targetPath); }
-
-            CruiseDesignMain.OpenExistingDesignFile(targetPath, fileContextProvider, logger, dialogService);
-
-            // verify error message shown
-            dialogService.Received().ShowMessage(Arg.Is("File Path Too Long"), Arg.Any<string>());
-        }
-
-        [Theory]
         [InlineData(".cruise")]
         [InlineData(".design")]
         [InlineData(".crz3")]

--- a/CruiseDesign.Test/CruiseDesignMain_Test_OpenExistingDesignFile.cs
+++ b/CruiseDesign.Test/CruiseDesignMain_Test_OpenExistingDesignFile.cs
@@ -20,8 +20,35 @@ namespace CruiseDesign.Test
         {
         }
 
+        [Theory]
+        [InlineData(270)]
+        [InlineData(260)]
+        [InlineData(258)]
 
+        public void OpenExistingDesignFile_PathTooLong(int desiredDirLength)
+        {
+            var fileName = "a.design";
+            var dir = base.TestTempPath;
+            var baseDirLength = dir.Length;
+            var neededExtraDirLength = desiredDirLength - baseDirLength - fileName.Length; 
 
+            var extraDir = new String('a', neededExtraDirLength);
+
+            var targetPath = Path.Combine(dir, extraDir, "a.design");
+            Output.WriteLine("TargetPath::::(" + targetPath.Length + ")" + targetPath);
+
+            var fileContextProvider = new CruiseDesignFileContextProvider();
+
+            var logger = MakeMockLogger();
+            var dialogService = MakeMockDialogService();
+
+            if (File.Exists(targetPath)) { File.Delete(targetPath); }
+
+            CruiseDesignMain.OpenExistingDesignFile(targetPath, fileContextProvider, logger, dialogService);
+
+            // verify error message shown
+            dialogService.Received().ShowMessage(Arg.Is("File Path Too Long"), Arg.Any<string>());
+        }
 
         [Theory]
         [InlineData(".cruise")]
@@ -42,7 +69,7 @@ namespace CruiseDesign.Test
 
             // verify error message shown
             dialogService.Received().ShowMessage(Arg.Is("Selected File Does Not Exist"), Arg.Any<string>());
-
+            dialogService.Received(1).ShowMessage(Arg.Any<string>(), Arg.Any<string>());
         }
 
         [Theory]

--- a/CruiseDesign.Test/Design_Pages/CreateProduction_Test.cs
+++ b/CruiseDesign.Test/Design_Pages/CreateProduction_Test.cs
@@ -354,7 +354,8 @@ namespace CruiseDesign.Test.Design_Pages
             }
         }
 
-        [Fact]
+
+        [Fact(Skip = "Not sure if anyone is going to get around to fixing this issue, it's likely that this issue is caused during the process of the cruise file")]
         public void Issue_CrashOn_findSgStatCN100()
         {
             var designPath = GetTestFile("JohnneysHazardousFuelReduction_20230313.design");

--- a/CruiseDesign.Test/Design_Pages/CreateProduction_Test.cs
+++ b/CruiseDesign.Test/Design_Pages/CreateProduction_Test.cs
@@ -102,6 +102,9 @@ namespace CruiseDesign.Test.Design_Pages
             CreateProduction.CreateProductionFile(dataFiles, fileContext, true, false, mockDialogService, logger);
 
             File.Exists(prodFilePath).Should().BeTrue();
+
+            using var prodDb = new CruiseDatastore_V3(prodFilePath);
+            VerifyProdFile(prodDb);
         }
 
         [Fact]
@@ -179,6 +182,9 @@ namespace CruiseDesign.Test.Design_Pages
             CreateProduction.CreateProductionFile(dataFiles, fileContext, true, false, mockDialogService, logger);
 
             File.Exists(prodFilePath).Should().BeTrue();
+
+            //using var prodDb = new CruiseDatastore_V3(prodFilePath);
+            //VerifyProdFile(prodDb);
         }
 
         [Fact]
@@ -218,6 +224,9 @@ namespace CruiseDesign.Test.Design_Pages
             CreateProduction.CreateProductionFile(dataFiles, fileContext, true, false, mockDialogService, logger);
 
             File.Exists(prodFilePath).Should().BeTrue();
+
+            using var prodDb = new CruiseDatastore_V3(prodFilePath);
+            VerifyProdFile(prodDb);
         }
 
 
@@ -238,7 +247,7 @@ namespace CruiseDesign.Test.Design_Pages
 
             using var designDb = new DAL(designPath);
 
-            var prodFilePath = GetTempFilePath("CreateProductionFiles_TestMeth_Prod.crz3");
+            var prodFilePath = GetTempFilePath("CreateProductionFile_V3_WithV3TemplateFile_Prod.crz3");
             var stCodes = designDb
                .From<CruiseDAL.V2.Models.Stratum>()
                .Query()
@@ -265,6 +274,7 @@ namespace CruiseDesign.Test.Design_Pages
             using var prodDb = new CruiseDatastore_V3(prodFilePath);
             using var templateDb = new CruiseDatastore_V3(v3TemplatePath);
             VerifyTemplateData(prodDb, templateDb);
+            VerifyProdFile(prodDb);
         }
 
         [Fact]
@@ -286,7 +296,7 @@ namespace CruiseDesign.Test.Design_Pages
 
             using var designDb = new DAL(designPath);
 
-            var prodFilePath = GetTempFilePath("CreateProductionFiles_TestMeth_Prod.crz3");
+            var prodFilePath = GetTempFilePath("CreateProductionFile_V3_WithV3Template_Prod.crz3");
             var stCodes = designDb
                .From<CruiseDAL.V2.Models.Stratum>()
                .Query()
@@ -312,6 +322,15 @@ namespace CruiseDesign.Test.Design_Pages
 
             using var prodDb = new CruiseDatastore_V3(prodFilePath);
             VerifyTemplateData(prodDb, templateDb);
+            VerifyProdFile(prodDb);
+        }
+
+
+        protected void VerifyProdFile(CruiseDatastore_V3 prodDb)
+        {
+            var result = prodDb.QueryGeneric2("SELECT t.* FROM Tree as t LEFT JOIN TallyLedger AS tl USING (TreeID) where tl.rowid is null", null).ToArray();
+
+            result.Should().BeEmpty(result.Length.ToString());
         }
 
         protected void VerifyTemplateData(CruiseDatastore_V3 cruiseDb, CruiseDatastore_V3 template)

--- a/CruiseDesign.Test/Services/CruiseDesignFileContext_Test.cs
+++ b/CruiseDesign.Test/Services/CruiseDesignFileContext_Test.cs
@@ -1,0 +1,48 @@
+﻿using CruiseDesign.Services;
+using NSubstitute;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CruiseDesign.Test.Services
+{
+    public class CruiseDesignFileContext_Test : TestBase
+    {
+        public CruiseDesignFileContext_Test(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Theory]
+        [InlineData(270)]
+        [InlineData(260)]
+        [InlineData(258)]
+
+        public void EnsurePathValid_PathTooLong(int desiredDirLength)
+        {
+            var fileName = "a.design";
+            var dir = base.TestTempPath;
+            var baseDirLength = dir.Length;
+            var neededExtraDirLength = desiredDirLength - baseDirLength - fileName.Length;
+
+            var extraDir = String.Concat(Enumerable.Range(1, neededExtraDirLength).Select(x => (x % 10)));
+
+            var targetPath = Path.Combine(dir, extraDir, "a.design");
+            Output.WriteLine("TargetPath::::(" + targetPath.Length + ")" + targetPath);
+
+            var logger = MakeMockLogger();
+            var dialogService = MakeMockDialogService();
+
+            if (File.Exists(targetPath)) { File.Delete(targetPath); }
+
+            CruiseDesignFileContext.EnsurePathValid(targetPath, logger, dialogService);
+
+            // verify error message shown
+            dialogService.Received().ShowMessage(Arg.Is("File Path Too Long"), Arg.Any<string>());
+        }
+    }
+}

--- a/CruiseDesign.iss
+++ b/CruiseDesign.iss
@@ -1,5 +1,5 @@
 #define MsBuildOutputDir ".\CruiseDesign\bin\Release\net472"
-#define VERSION "2023.10.30"
+#define VERSION "2024.01.18"
 
 #define APP "Cruise Design"
 #define EXEName "CruiseDesign.exe"

--- a/CruiseDesign/CruiseDesign.csproj
+++ b/CruiseDesign/CruiseDesign.csproj
@@ -58,6 +58,7 @@
 	</ItemGroup>	
 
 	<ItemGroup>
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.5"  />
 		<PackageReference Include="CruiseDAL.V2" Version="2.7.4.122" />
 		<PackageReference Include="CruiseDAL.V3" Version="3.6.5.122" />
 		<PackageReference Include="CruiseDAL.V3.Sync" Version="3.6.5.12200" />
@@ -65,7 +66,6 @@
 		<PackageReference Include="Microsoft.AppCenter.Analytics" Version="5.0.3" />
 		<PackageReference Include="Microsoft.AppCenter.Crashes" Version="5.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.6" />
 	</ItemGroup>
 
 	<Target Name="GenerateSecrets" BeforeTargets="CoreBuild">

--- a/CruiseDesign/CruiseDesignMain.cs
+++ b/CruiseDesign/CruiseDesignMain.cs
@@ -613,53 +613,11 @@ namespace CruiseDesign
 
         public static void OpenExistingDesignFile(string path, ICruiseDesignFileContextProvider fileContextProvider, ILogger logger, IDialogService dialogService)
         {
-            try
+            if(!CruiseDesignFileContext.EnsurePathValid(path, logger, dialogService))
             {
-                path = Path.GetFullPath(path);
-
-                // in net6.2 and later long paths are supported by default.
-                // however it can still cause issue. So we need to manual check the
-                // directory length
-                // 
-                var dirName = Path.GetDirectoryName(path);
-                if (dirName.Length >= 248 || path.Length >= 260)
-                {
-                    throw new PathTooLongException("The supplied path is too long");
-                }
-            }
-            catch (PathTooLongException ex)
-            {
-                var message = "File Path Too Long";
-                logger.LogError(ex, message);
-                dialogService.ShowMessage(message, "Error");
-                return;
-            }
-            catch (SecurityException ex)
-            {
-                var message = "Can Not Open File Due To File Permissions";
-                logger.LogError(ex, message);
-                dialogService.ShowMessage(message, "Error");
-                return;
-            }
-            catch (ArgumentException ex)
-            {
-                var message = (!string.IsNullOrEmpty(path) && path.IndexOfAny(Path.GetInvalidPathChars()) != -1)
-                    ? "Path Contains Invalid Characters" : "Invalid File Path";
-                logger.LogError(ex, message);
-                dialogService.ShowMessage(message, "Error");
                 return;
             }
 
-
-            if (!File.Exists(path))
-            {
-                var message = "Selected File Does Not Exist";
-                logger.LogWarning(message);
-                dialogService.ShowMessage(message, "Warning");
-                return;
-            }
-
-            
             //if(File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly))
             //{ dialogService.ShowMessage("Selected File Is Read Only"); }
 

--- a/CruiseDesign/CruiseDesignMain.cs
+++ b/CruiseDesign/CruiseDesignMain.cs
@@ -616,6 +616,16 @@ namespace CruiseDesign
             try
             {
                 path = Path.GetFullPath(path);
+
+                // in net6.2 and later long paths are supported by default.
+                // however it can still cause issue. So we need to manual check the
+                // directory length
+                // 
+                var dirName = Path.GetDirectoryName(path);
+                if (dirName.Length >= 248 || path.Length >= 260)
+                {
+                    throw new PathTooLongException("The supplied path is too long");
+                }
             }
             catch (PathTooLongException ex)
             {

--- a/CruiseDesign/Design_Pages/CreateProduction.cs
+++ b/CruiseDesign/Design_Pages/CreateProduction.cs
@@ -297,7 +297,7 @@ namespace CruiseDesign.Design_Pages
                 v3Db.Execute("DELETE FROM " + nameof(BiomassEquation) + ";");
             }
 
-            var templateCopier = new TemplateCopier() { DefaultOnConflictOption = Backpack.SqlBuilder.OnConflictOption.Replace };
+            var templateCopier = new TemplateCopier() { DefaultOnConflictOption = Backpack.SqlBuilder.OnConflictOption.Ignore };
             templateCopier.Copy(templateSourceDb, v3Db, sourceCruiseID, destCruiseID);
         }
 

--- a/CruiseDesign/Design_Pages/CreateProduction.cs
+++ b/CruiseDesign/Design_Pages/CreateProduction.cs
@@ -110,6 +110,11 @@ namespace CruiseDesign.Design_Pages
                 destPath = null;
             }
 
+            if (!CruiseDesignFileContext.EnsurePathValid(destPath, Logger, DialogService))
+            {
+                return;
+            }
+
             _destPath = destPath;
             textBoxFile.Text = _destPath;
         }

--- a/CruiseDesign/HistoricalSetupWizard.cs
+++ b/CruiseDesign/HistoricalSetupWizard.cs
@@ -32,11 +32,13 @@ namespace CruiseDesign
             InitializeComponent();
         }
 
-        public HistoricalSetupWizard(ICruiseDesignFileContextProvider fileContextProvider, ILogger<HistoricalSetupWizard> logger)
+        public HistoricalSetupWizard(ICruiseDesignFileContextProvider fileContextProvider, ILogger<HistoricalSetupWizard> logger, IDialogService dialogService)
             : this()
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             var fileContext = fileContextProvider.CurrentFileContext;
+
+            DialogService = dialogService;
 
             cdDAL = fileContext.DesignDb;
             setSalePurpose();
@@ -51,6 +53,8 @@ namespace CruiseDesign
 
         public ArrayList selectedUnits = new ArrayList();
         public String UOM;
+
+        public IDialogService DialogService { get; }
 
         // add the binding lists
         public DAL cdDAL { get; set; }
@@ -104,6 +108,8 @@ namespace CruiseDesign
 
         public void OpenHistoricalCruiseFile(string path)
         {
+            if(!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)) return;
+
             //open new cruise DAL
             if (!string.IsNullOrEmpty(path) && File.Exists(path))
             {

--- a/CruiseDesign/Historical_setup/SaleSetupPage.cs
+++ b/CruiseDesign/Historical_setup/SaleSetupPage.cs
@@ -17,6 +17,7 @@ namespace CruiseDesign.Historical_setup
     public partial class SaleSetupPage : Form
     {
         public ILogger Logger { get; }
+        public IDialogService DialogService { get; }
 
         #region Constructor
 
@@ -25,10 +26,11 @@ namespace CruiseDesign.Historical_setup
             InitializeComponent();
         }
 
-        public SaleSetupPage(ICruiseDesignFileContextProvider fileContextProvider, ILogger<SaleSetupPage> logger)
+        public SaleSetupPage(ICruiseDesignFileContextProvider fileContextProvider, ILogger<SaleSetupPage> logger, IDialogService dialogService)
               : this()
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            DialogService = dialogService;
 
             var fileContext = fileContextProvider.CurrentFileContext;
             df.cdDAL = fileContext.DesignDb;
@@ -64,7 +66,10 @@ namespace CruiseDesign.Historical_setup
             openFileDialog1.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments) + "\\CruiseFiles\\Templates";
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
             {
-                templateFilePath = openFileDialog1.FileName;
+                var path = openFileDialog1.FileName;
+                if (!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)) return;
+
+                templateFilePath = path;
 
                 textBoxFile.Text = openFileDialog1.SafeFileName;
 

--- a/CruiseDesign/Program.cs
+++ b/CruiseDesign/Program.cs
@@ -25,6 +25,8 @@ namespace CruiseDesign
         [STAThread]
         private static void Main(string[] args)
         {
+            SQLitePCL.Batteries_V2.Init();
+
 #if !DEBUG
             Microsoft.AppCenter.AppCenter.Start(Secrets.CRUISEDESIGN_APPCENTER_KEY_WINDOWS,
                                typeof(Microsoft.AppCenter.Analytics.Analytics), typeof(Microsoft.AppCenter.Crashes.Crashes));

--- a/CruiseDesign/Program.cs
+++ b/CruiseDesign/Program.cs
@@ -27,8 +27,6 @@ namespace CruiseDesign
         [STAThread]
         private static void Main(string[] args)
         {
-            SQLitePCL.Batteries_V2.Init();
-
 #if !DEBUG
             Microsoft.AppCenter.AppCenter.Start(Secrets.CRUISEDESIGN_APPCENTER_KEY_WINDOWS,
                                typeof(Microsoft.AppCenter.Analytics.Analytics), typeof(Microsoft.AppCenter.Crashes.Crashes));

--- a/CruiseDesign/Program.cs
+++ b/CruiseDesign/Program.cs
@@ -7,10 +7,12 @@ using CruiseDesign.Services.Logging;
 using CruiseDesign.Stats;
 using CruiseDesign.Strata_setup;
 using FMSC.Controls;
+using Microsoft.AppCenter;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Diagnostics;
 using System.Windows.Forms;
 
 namespace CruiseDesign
@@ -30,6 +32,13 @@ namespace CruiseDesign
 #if !DEBUG
             Microsoft.AppCenter.AppCenter.Start(Secrets.CRUISEDESIGN_APPCENTER_KEY_WINDOWS,
                                typeof(Microsoft.AppCenter.Analytics.Analytics), typeof(Microsoft.AppCenter.Crashes.Crashes));
+#else
+            ApplicationLifecycleHelper.Instance.UnhandledExceptionOccurred += Instance_UnhandledExceptionOccurred;
+
+            static void Instance_UnhandledExceptionOccurred(object sender, Microsoft.AppCenter.Utils.UnhandledExceptionOccurredEventArgs e)
+            {
+                Debug.WriteLine("UNHANDLED APPLICATION EXCEPTION::::\r\n" + e.Exception);
+            }
 #endif
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<Copyright>CC0 Public Domain</Copyright>
 		<Company>USDA Forest Service</Company>
 		<Authors>Ken Cormier</Authors>
-		<Version>2023.10.30</Version>
+		<Version>2024.01.18</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Build Config">


### PR DESCRIPTION
# Fixes
 - Fix Issue with zero tree count when creating V3 production cruise
 - Fix crash when using historical setup
 - Fix crash when opening files with too long file path, or other invalid file path. 

# Release Checklist
 - [x] Run all tests in CruiseDesign.Test
 - [x] Update **Version** property in `/Directory.Build.props` file
 - [x] Update **VERSION** value in `/CruiseDesign.iss`
 - [x] Run Build_Installer.bat and confirm output file exists `/Artifacts/[date code]/CruiseDesign_Setup_[version].exe`
 - [x] Build_ZipArtifact.cmd and confirm output file exists `/Artifacts/[date code]/CruiseDesign.zip`
 - [x] Create Release Documents on Pynion : `\EADBranchWideShare\Projectss_in_Development\National-Cruise-System\Release Documents\CruiseDesign\<version number>`
   - [x] Update SIA and Release Management Docs using copy from previous release as template
   - [ ] Create and Email Release Document using template from `\EADBranchWideShate\Communications\Templates\Release Templates\`
 - [ ] Submit Release to Release Management using Service Now
