### PR TITLE
Cruise Design v2024.02.02

### DIFF
--- a/CruiseDesign.Test/CruiseDesignMain_Test_Startup.cs
+++ b/CruiseDesign.Test/CruiseDesignMain_Test_Startup.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace CruiseDesign.Test
+{
+    public class CruiseDesignMain_Test_Startup : TestBase
+    {
+        public CruiseDesignMain_Test_Startup(ITestOutputHelper output) : base(output)
+        {
+        }
+
+
+        [Fact(Skip = "Because test launches UI. Remove skip to run test manually")]
+        public void ProgramStarts()
+        {
+            CruiseDesign.Program.Main(new string[0]);
+        }
+
+        [Fact(Skip = "Because test launches UI. Remove skip to run test manually")]
+        public void ProgramStarts_WithArgs()
+        {
+            var testFilePath = GetTestFile("99996_TestMeth_Timber_Sale_08072021.design");
+            var args = new[] { testFilePath };
+
+            CruiseDesign.Program.Main(args);
+        }
+
+        [Fact(Skip = "Because test launches UI. Remove skip to run test manually")]
+        public void ProgramStarts_WithArgs_ReadOnlyFile()
+        {
+            var testFilePath = GetTestFile("99996_TestMeth_Timber_Sale_08072021.design");
+
+            var readOnlyFilePath = Path.Combine(TestTempPath, "ProgramStarts_WithArgs_ReadOnlyFile.design");
+            if (!File.Exists(readOnlyFilePath))
+            {
+                File.Copy(testFilePath, readOnlyFilePath);
+                File.SetAttributes(readOnlyFilePath, FileAttributes.ReadOnly);
+            }
+
+            var args = new[] { readOnlyFilePath };
+
+            CruiseDesign.Program.Main(args);
+        }
+
+    }
+}

--- a/CruiseDesign.iss
+++ b/CruiseDesign.iss
@@ -1,5 +1,5 @@
 #define MsBuildOutputDir ".\CruiseDesign\bin\Release\net472"
-#define VERSION "2024.01.18"
+#define VERSION "2024.02.01"
 
 #define APP "Cruise Design"
 #define EXEName "CruiseDesign.exe"

--- a/CruiseDesign.iss
+++ b/CruiseDesign.iss
@@ -1,5 +1,5 @@
 #define MsBuildOutputDir ".\CruiseDesign\bin\Release\net472"
-#define VERSION "2024.02.01"
+#define VERSION "2024.02.02"
 
 #define APP "Cruise Design"
 #define EXEName "CruiseDesign.exe"

--- a/CruiseDesign/CruiseDesign.csproj
+++ b/CruiseDesign/CruiseDesign.csproj
@@ -17,6 +17,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="CruiseDesign.Test" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<EmbeddedResource Remove="StrataSetup.resx" />
 		<EmbeddedResource Remove="Strata_setup\CuttingUnitsPage.resx" />
 		<EmbeddedResource Remove="Strata_setup\Form1.resx" />
@@ -58,7 +62,8 @@
 	</ItemGroup>	
 
 	<ItemGroup>
-		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.5"  />
+		<PackageReference Include="CruiseDAL.V3.DownConvert" Version="3.6.5.12200" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.5" />
 		<PackageReference Include="CruiseDAL.V2" Version="2.7.4.122" />
 		<PackageReference Include="CruiseDAL.V3" Version="3.6.5.122" />
 		<PackageReference Include="CruiseDAL.V3.Sync" Version="3.6.5.12200" />

--- a/CruiseDesign/CruiseDesignMain.Designer.cs
+++ b/CruiseDesign/CruiseDesignMain.Designer.cs
@@ -388,7 +388,6 @@
             // 
             // openFileDialogCruise
             // 
-            this.openFileDialogCruise.DefaultExt = "cruise";
             this.openFileDialogCruise.DereferenceLinks = false;
             this.openFileDialogCruise.FilterIndex = 3;
             this.openFileDialogCruise.Filter = "All Files|*.cruise;*.crz3;*.design|Design files|*.design|Cruise files|*.cruise;*.crz3";
@@ -396,13 +395,11 @@
             // 
             // openFileDialogDesign
             // 
-            this.openFileDialogDesign.FileName = "*.design";
             this.openFileDialogDesign.Filter = "All Files|*.cruise;*.crz3;*.design|Design files|*.design|Cruise files|*.cruise;*.crz3";
             // 
             // saveFileDialogDesign
             // 
-            this.saveFileDialogDesign.DefaultExt = "*.design";
-            this.saveFileDialogDesign.FileName = "*.design";
+            this.saveFileDialogDesign.DefaultExt = "design";
             this.saveFileDialogDesign.Filter = "Cruise Design files|*.design|All files|*.*";
             // 
             // CruiseDesignMain

--- a/CruiseDesign/CruiseDesignMain.cs
+++ b/CruiseDesign/CruiseDesignMain.cs
@@ -613,7 +613,8 @@ namespace CruiseDesign
 
         public static void OpenExistingDesignFile(string path, ICruiseDesignFileContextProvider fileContextProvider, ILogger logger, IDialogService dialogService)
         {
-            if(!CruiseDesignFileContext.EnsurePathValid(path, logger, dialogService))
+            if(!CruiseDesignFileContext.EnsurePathValid(path, logger, dialogService)
+                && !CruiseDesignFileContext.EnsurePathExists(path, logger, dialogService))
             {
                 return;
             }

--- a/CruiseDesign/CruiseDesignMain.cs
+++ b/CruiseDesign/CruiseDesignMain.cs
@@ -11,7 +11,6 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Security;
 using System.Windows.Forms;
 
 namespace CruiseDesign
@@ -46,48 +45,60 @@ namespace CruiseDesign
             }
         }
 
+        public string[] OpenArgs { get; }
+
         protected CruiseDesignMain()
         {
             InitializeComponent();
         }
 
         public CruiseDesignMain(string[] args, IServiceProvider serviceProvider, ILogger<CruiseDesignMain> logger, ICruiseDesignFileContextProvider fileContextProvider, IDialogService dialogService)
-            : this(serviceProvider, logger, fileContextProvider)
+            : this(serviceProvider, logger, fileContextProvider, dialogService)
         {
-            DialogService = dialogService;
-            // to update version change the Version property in the project file
-            var version = Assembly.GetEntryAssembly().GetName().Version?.ToString(3);
-            this.Text = $"Cruise Design {version}";
-
-            if (args.Length != 0)
-            {
-                var newFileContext = new CruiseDesignFileContext()
-                { DesignFilePath = Convert.ToString(args[0]) };
-
-                newFileContext.SetReconFilePathFromDesign();
-
-                if (newFileContext.OpenDesignFile(Logger))
-                {
-                    FileContextProvider.CurrentFileContext = newFileContext;
-                }
-                else
-                {
-                    MessageBox.Show("Unable to open the design file", "Information");
-                }
-            }
-
-            Logger.LogInformation("Program Started");
+            OpenArgs = args;
         }
 
-        public CruiseDesignMain(IServiceProvider serviceProvider, ILogger<CruiseDesignMain> logger, ICruiseDesignFileContextProvider fileContextProvider)
+        protected CruiseDesignMain(IServiceProvider serviceProvider, ILogger<CruiseDesignMain> logger, ICruiseDesignFileContextProvider fileContextProvider, IDialogService dialogService)
             : this()
         {
+            DialogService = dialogService;
             ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             FileContextProvider = fileContextProvider ?? throw new ArgumentNullException(nameof(fileContextProvider));
 
-            var version = Assembly.GetEntryAssembly().GetName().Version?.ToString(3);
+            var version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString(3);
             this.Text = $"Cruise Design {version}";
+
+            Logger.LogInformation("Program Started");
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+
+            var args = OpenArgs;
+            if (args != null && args.Length != 0)
+            {
+                var filePath = Convert.ToString(args[0]);
+                if (CruiseDesignFileContext.EnsurePathValid(filePath, Logger, DialogService)
+                && CruiseDesignFileContext.EnsurePathExistsAndCanWrite(filePath, Logger, DialogService))
+                {
+                    var newFileContext = new CruiseDesignFileContext()
+                    { DesignFilePath = filePath };
+
+                    newFileContext.SetReconFilePathFromDesign();
+
+                    if (newFileContext.OpenDesignFile(Logger))
+                    {
+                        FileContextProvider.CurrentFileContext = newFileContext;
+                    }
+                    else
+                    {
+                        MessageBox.Show("Unable to open the design file", "Information");
+                    }
+                }
+            }
+
         }
 
         private void OnFileContextChanged(object sender, EventArgs e)
@@ -614,7 +625,7 @@ namespace CruiseDesign
         public static void OpenExistingDesignFile(string path, ICruiseDesignFileContextProvider fileContextProvider, ILogger logger, IDialogService dialogService)
         {
             if(!CruiseDesignFileContext.EnsurePathValid(path, logger, dialogService)
-                && !CruiseDesignFileContext.EnsurePathExists(path, logger, dialogService))
+                && !CruiseDesignFileContext.EnsurePathExistsAndCanWrite(path, logger, dialogService))
             {
                 return;
             }

--- a/CruiseDesign/HistoricalSetupWizard.Designer.cs
+++ b/CruiseDesign/HistoricalSetupWizard.Designer.cs
@@ -46,9 +46,7 @@ namespace CruiseDesign
          // 
          // openFileDialog1
          // 
-         this.openFileDialog1.DefaultExt = "cruise";
-         this.openFileDialog1.FileName = "*.cruise";
-         this.openFileDialog1.Filter = "Cruise files|*.cruise|All files|*.*";
+         this.openFileDialog1.Filter = "Cruise files|*.cruise;*.crz3|All files|*.*";
          // 
          // pageHost2
          // 

--- a/CruiseDesign/HistoricalSetupWizard.cs
+++ b/CruiseDesign/HistoricalSetupWizard.cs
@@ -108,27 +108,21 @@ namespace CruiseDesign
 
         public void OpenHistoricalCruiseFile(string path)
         {
-            if(!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)) return;
+            if(!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)
+                && !CruiseDesignFileContext.EnsurePathExists(path, Logger, DialogService)) return;
 
             //open new cruise DAL
-            if (!string.IsNullOrEmpty(path) && File.Exists(path))
+            try
             {
-                try
-                {
-                    hDAL = new DAL(path);
-                }
-                catch (System.IO.IOException ie)
-                {
-                    Logger.LogError(ie, "");
-                }
-                catch (System.Exception ie)
-                {
-                    Logger.LogError(ie, "");
-                }
+                hDAL = new DAL(path);
             }
-            else
+            catch (System.IO.IOException ie)
             {
-                return;
+                Logger.LogError(ie, "");
+            }
+            catch (System.Exception ie)
+            {
+                Logger.LogError(ie, "");
             }
 
             Sale = new SaleDO(hDAL.From<SaleDO>().Read().FirstOrDefault());

--- a/CruiseDesign/HistoricalSetupWizard.cs
+++ b/CruiseDesign/HistoricalSetupWizard.cs
@@ -2,6 +2,7 @@
 using CruiseDAL.DataObjects;
 using CruiseDesign.Historical_setup;
 using CruiseDesign.Services;
+using FMSC.ORM.Core;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections;
@@ -109,7 +110,32 @@ namespace CruiseDesign
         public void OpenHistoricalCruiseFile(string path)
         {
             if(!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)
-                && !CruiseDesignFileContext.EnsurePathExists(path, Logger, DialogService)) return;
+                && !CruiseDesignFileContext.EnsurePathExistsAndCanWrite(path, Logger, DialogService)) return;
+
+            var fileExtention = Path.GetExtension(path).Trim();
+            if(fileExtention == ".crz3")
+            {
+                var processFilePath = CruiseDesignFileContext.GetProcessFilePathFromV3Cruise(path);
+
+                if(!CruiseDesignFileContext.EnsurePathValid(processFilePath, Logger, DialogService)) { return; }
+                if (!File.Exists(processFilePath))
+                {
+                    var message = ".process File Does Not Exist for V3 Cruise.\r\nPlease process file first.";
+                    Logger.LogWarning(message);
+                    DialogService.ShowMessage(message, "Warning");
+                    return;
+                }
+
+                if (File.GetAttributes(processFilePath).HasFlag(FileAttributes.ReadOnly))
+                {
+                    var message = ".process File Is Read Only.\r\nIf opening file from non-local location, please copy file to a location on your PC before opening.";
+                    Logger.LogWarning(message);
+                    DialogService.ShowMessage(message, "Warning");
+                    return;
+                }
+
+                path = processFilePath;
+            }
 
             //open new cruise DAL
             try

--- a/CruiseDesign/Historical_setup/SaleSetupPage.Designer.cs
+++ b/CruiseDesign/Historical_setup/SaleSetupPage.Designer.cs
@@ -270,9 +270,7 @@
          // 
          // openFileDialog1
          // 
-         this.openFileDialog1.DefaultExt = "cut";
-         this.openFileDialog1.FileName = "*.cut";
-         this.openFileDialog1.Filter = "Cruise template|*.cut|All files|*.*";
+         this.openFileDialog1.Filter = "Cruise template|*.cut;*.crz3t|All files|*.*";
          // 
          // labelWorking
          // 

--- a/CruiseDesign/Historical_setup/SaleSetupPage.cs
+++ b/CruiseDesign/Historical_setup/SaleSetupPage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
@@ -68,7 +69,9 @@ namespace CruiseDesign.Historical_setup
             {
                 var path = openFileDialog1.FileName;
                 if (!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)
-                    && !CruiseDesignFileContext.EnsurePathExists(path, Logger, DialogService)) return;
+                    && !CruiseDesignFileContext.EnsurePathExistsAndCanWrite(path, Logger, DialogService)) return;
+
+
 
                 templateFilePath = path;
 

--- a/CruiseDesign/Historical_setup/SaleSetupPage.cs
+++ b/CruiseDesign/Historical_setup/SaleSetupPage.cs
@@ -67,7 +67,8 @@ namespace CruiseDesign.Historical_setup
             if (openFileDialog1.ShowDialog() == DialogResult.OK)
             {
                 var path = openFileDialog1.FileName;
-                if (!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)) return;
+                if (!CruiseDesignFileContext.EnsurePathValid(path, Logger, DialogService)
+                    && !CruiseDesignFileContext.EnsurePathExists(path, Logger, DialogService)) return;
 
                 templateFilePath = path;
 

--- a/CruiseDesign/Program.cs
+++ b/CruiseDesign/Program.cs
@@ -25,7 +25,7 @@ namespace CruiseDesign
         /// The main entry point for the application.
         /// </summary>
         [STAThread]
-        private static void Main(string[] args)
+        internal static void Main(string[] args)
         {
 #if !DEBUG
             Microsoft.AppCenter.AppCenter.Start(Secrets.CRUISEDESIGN_APPCENTER_KEY_WINDOWS,

--- a/CruiseDesign/Reports/ReportForm.Designer.cs
+++ b/CruiseDesign/Reports/ReportForm.Designer.cs
@@ -294,7 +294,7 @@
          // 
          // saveFileDialog1
          // 
-         this.saveFileDialog1.FileName = "*.xps";
+         this.saveFileDialog1.DefaultExt = "xps";
          this.saveFileDialog1.Filter = "Cruise Design Report|*.xps";
          // 
          // labelTime

--- a/CruiseDesign/Services/CruiseDesignFileContext.cs
+++ b/CruiseDesign/Services/CruiseDesignFileContext.cs
@@ -221,11 +221,19 @@ namespace CruiseDesign.Services
             return true;
         }
 
-        public static bool EnsurePathExists(string path, ILogger logger, IDialogService dialogService)
+        public static bool EnsurePathExistsAndCanWrite(string path, ILogger logger, IDialogService dialogService)
         {
             if (!File.Exists(path))
             {
                 var message = "Selected File Does Not Exist";
+                logger.LogWarning(message);
+                dialogService.ShowMessage(message, "Warning");
+                return false;
+            }
+
+            if (File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly))
+            {
+                var message = "Selected File Is Read Only.\r\nIf opening file from non-local location, please copy file to a location on your PC before opening.";
                 logger.LogWarning(message);
                 dialogService.ShowMessage(message, "Warning");
                 return false;

--- a/CruiseDesign/Services/CruiseDesignFileContext.cs
+++ b/CruiseDesign/Services/CruiseDesignFileContext.cs
@@ -96,7 +96,7 @@ namespace CruiseDesign.Services
         {
             var designFilePath = DesignFilePath;
             var v3FilePath = Path.ChangeExtension(designFilePath, ".crz3");
-            if(File.Exists(v3FilePath))
+            if (File.Exists(v3FilePath))
             {
                 V3FilePath = v3FilePath;
                 return true;
@@ -218,7 +218,11 @@ namespace CruiseDesign.Services
                 return false;
             }
 
+            return true;
+        }
 
+        public static bool EnsurePathExists(string path, ILogger logger, IDialogService dialogService)
+        {
             if (!File.Exists(path))
             {
                 var message = "Selected File Does Not Exist";

--- a/CruiseDesign/Services/DialogService.cs
+++ b/CruiseDesign/Services/DialogService.cs
@@ -90,7 +90,7 @@ namespace CruiseDesign.Services
         {
             var fileDialog = new SaveFileDialog()
             {
-                DefaultExt = (defaultV3) ? ".crz3" : ".cruise",
+                DefaultExt = (defaultV3) ? "crz3" : "cruise",
                 Filter = "V2 Cruise File|*.cruise|V3 Cruise File|*.crz3",
                 FileName = defaultFileName,
             };

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<Copyright>CC0 Public Domain</Copyright>
 		<Company>USDA Forest Service</Company>
 		<Authors>Ken Cormier</Authors>
-		<Version>2024.01.18</Version>
+		<Version>2024.02.01</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Build Config">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<Copyright>CC0 Public Domain</Copyright>
 		<Company>USDA Forest Service</Company>
 		<Authors>Ken Cormier</Authors>
-		<Version>2024.02.01</Version>
+		<Version>2024.02.02</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Label="Build Config">


### PR DESCRIPTION
# Fixes
- Fix unable to select destination for production cruise

# Enhancements
- Add ability to select V3 template when creating design from historical

# Release Checklist
 - [x] Run all tests in CruiseDesign.Test
 - [x] Update **Version** property in `/Directory.Build.props` file
 - [x] Update **VERSION** value in `/CruiseDesign.iss`
 - [x] Run Build_Installer.bat and confirm output file exists `/Artifacts/[date code]/CruiseDesign_Setup_[version].exe`
 - [x] Build_ZipArtifact.cmd and confirm output file exists `/Artifacts/[date code]/CruiseDesign.zip`
 - [x] Create Release Documents on Pynion : `\EADBranchWideShare\Projectss_in_Development\National-Cruise-System\Release Documents\CruiseDesign\<version number>`
   - [x] Undate SIA and Release Managmet Docs using copy from previouse release as template
   - [ ] Create and Email Release Document using template from `\EADBranchWideShate\Communications\Templates\Release Templates\`
 - [x] Submit Release to Release Managment using Service Now
